### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ It'll create a volume on the fly in which the command gets executed and create t
 
 To update the package you'll need to rebuild the image.
 
-Hint: You can also create an alias to use greybel-js but create a function since a regular alias would cache the pwd command's value on the first execution:
+Hint: You can also create an alias to use greybel-js but it should be created as a function instead of a regular alias since the latter would cache the pwd command's value on the first execution:
+
 ```
 greybel-cli() {
     docker run -i -v $(pwd):/app greybel-cli $@

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ It'll create a volume on the fly in which the command gets executed and create t
 
 To update the package you'll need to rebuild the image.
 
-Hint: You can also create an alias to use greybel-js:
+Hint: You can also create an alias to use greybel-js but create a function since a regular alias would cache the pwd command's value on the first execution:
 ```
-alias greybel-cli="docker run -i -v "$(pwd):/app" greybel-cli"
+greybel-cli() {
+    docker run -i -v $(pwd):/app greybel-cli $@
+}
 ```
 After the alias is in place greybel-js can be used like this: 
 ```


### PR DESCRIPTION
The alias of greybel-cli if is assigned as a regular alias the first time executed bash will cache the pwd command's value so it will work only on the first directory executed, to avoid that behavior the alias should be a function.