### PR TITLE
3.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1050,4 +1050,4 @@ All notable changes to this project will be documented in this file.
 
 ## [3.2.13] - 23.01.2024
 
-- use proper parser package for UI to prevent possible errors which are related to MiniScript but not to GreyScript
+- use proper parser package for UI to prevent possible syntax errors which are related to MiniScript but not to GreyScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1047,3 +1047,7 @@ All notable changes to this project will be documented in this file.
 
 - improve parser recovery from invalid syntax
 - use backpatching to enable similar MiniScript parsing of blocks, this may cause previous valid greybel syntax to be invalid especially when it comes to function blocks
+
+## [3.2.13] - 23.01.2024
+
+- use proper parser package for UI to prevent possible errors which are related to MiniScript but not to GreyScript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "greybel-js",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "greybel-js",
-            "version": "3.2.12",
+            "version": "3.2.13",
             "dependencies": {
                 "@babel/runtime": "^7.16.7",
                 "@inquirer/core": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "greybel-js",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "engines": {
         "node": ">=18.17.0"
     },

--- a/src/web/extension/helper/model-manager.ts
+++ b/src/web/extension/helper/model-manager.ts
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import { ASTChunkAdvanced, Parser } from 'greybel-core';
+import { ASTChunkGreyScript, Parser } from 'greyscript-core';
 import LRU from 'lru-cache';
 import { ASTBase } from 'miniscript-core';
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
@@ -74,8 +74,8 @@ export class DocumentParseQueue extends EventEmitter {
     });
     const chunk = parser.parseChunk();
 
-    if ((chunk as ASTChunkAdvanced).body?.length > 0) {
-      typeManager.analyze(document, chunk as ASTChunkAdvanced);
+    if ((chunk as ASTChunkGreyScript).body?.length > 0) {
+      typeManager.analyze(document, chunk as ASTChunkGreyScript);
 
       return {
         content,
@@ -89,7 +89,7 @@ export class DocumentParseQueue extends EventEmitter {
       const strictParser = new Parser(document.getValue());
       const strictChunk = strictParser.parseChunk();
 
-      typeManager.analyze(document, strictChunk as ASTChunkAdvanced);
+      typeManager.analyze(document, strictChunk as ASTChunkGreyScript);
 
       return {
         content,


### PR DESCRIPTION
Includes:
- use proper parser package for UI to prevent possible syntax errors which are related to MiniScript but not to GreyScript