### PR TITLE
3.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1164,3 +1164,10 @@ All notable changes to this project will be documented in this file.
 ## [3.3.10] - 26.06.2024
 
 - minor optimizations regarding type resolver such as resolving types through parentheses, keeping api definitions apart from custom definitions preventing unwanted merged definitions, using a proxy container for signature definitions and fixing line overriding for identifier causing to use wrong start lines
+
+## [3.3.11] - 01.07.2024
+
+- add super keyword to type-analyzer
+- fix member expression containing new unary when resolving type
+- only use shallow copy when copying entity to avoid memory exhaustion for type-analyzer
+- properly resolve members of scope variables and api definitions for type-analyzer

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "greyscript-transpiler": "~0.8.3",
         "is-inside-container": "^1.0.0",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.4.3",
+        "miniscript-type-analyzer": "~0.4.4",
         "mkdirp": "^1.0.4",
         "monaco-textmate-provider": "^1.3.0",
         "node-persist": "^3.1.3",
@@ -6999,9 +6999,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
-      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
+      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -14706,9 +14706,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
-      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
+      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.3.10",
+      "version": "3.3.11",
       "dependencies": {
         "@babel/runtime": "^7.16.7",
         "@inquirer/core": "^1.0.1",
@@ -28,7 +28,7 @@
         "greyscript-transpiler": "~0.8.3",
         "is-inside-container": "^1.0.0",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.3.10",
+        "miniscript-type-analyzer": "~0.4.2",
         "mkdirp": "^1.0.4",
         "monaco-textmate-provider": "^1.3.0",
         "node-persist": "^3.1.3",
@@ -6999,9 +6999,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.3.10.tgz",
-      "integrity": "sha512-uP08qfCxmRfAjP2l9DQIMq9teeWdLkmCWhshT7drxhUpQX0tuks9UcE/VgTJ5mdUCpmOCgbvdQlncyPaw+0jIQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
+      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -14706,9 +14706,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.3.10.tgz",
-      "integrity": "sha512-uP08qfCxmRfAjP2l9DQIMq9teeWdLkmCWhshT7drxhUpQX0tuks9UcE/VgTJ5mdUCpmOCgbvdQlncyPaw+0jIQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
+      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "greyscript-transpiler": "~0.8.3",
         "is-inside-container": "^1.0.0",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.4.2",
+        "miniscript-type-analyzer": "~0.4.3",
         "mkdirp": "^1.0.4",
         "monaco-textmate-provider": "^1.3.0",
         "node-persist": "^3.1.3",
@@ -6999,9 +6999,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
-      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
+      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -14706,9 +14706,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
-      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
+      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "greyscript-transpiler": "~0.8.3",
         "is-inside-container": "^1.0.0",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.4.4",
+        "miniscript-type-analyzer": "~0.4.5",
         "mkdirp": "^1.0.4",
         "monaco-textmate-provider": "^1.3.0",
         "node-persist": "^3.1.3",
@@ -6999,9 +6999,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
-      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.5.tgz",
+      "integrity": "sha512-HR8SNvHkGPY/U/sCCy9JSBRBfoq5v44eQtxJbQHry1rMYdanfYOEuUaP4yLLtwylG8jHh2p7COBe7u/SSYHvtw==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -14706,9 +14706,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
-      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.5.tgz",
+      "integrity": "sha512-HR8SNvHkGPY/U/sCCy9JSBRBfoq5v44eQtxJbQHry1rMYdanfYOEuUaP4yLLtwylG8jHh2p7COBe7u/SSYHvtw==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lru-cache": "^7.14.1",
     "mkdirp": "^1.0.4",
     "monaco-textmate-provider": "^1.3.0",
-    "miniscript-type-analyzer": "~0.4.3",
+    "miniscript-type-analyzer": "~0.4.4",
     "node-persist": "^3.1.3",
     "open": "^8.2.1",
     "pacote": "^15.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lru-cache": "^7.14.1",
     "mkdirp": "^1.0.4",
     "monaco-textmate-provider": "^1.3.0",
-    "miniscript-type-analyzer": "~0.4.4",
+    "miniscript-type-analyzer": "~0.4.5",
     "node-persist": "^3.1.3",
     "open": "^8.2.1",
     "pacote": "^15.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "engines": {
     "node": ">=18.17.0"
   },
@@ -44,7 +44,7 @@
     "lru-cache": "^7.14.1",
     "mkdirp": "^1.0.4",
     "monaco-textmate-provider": "^1.3.0",
-    "miniscript-type-analyzer": "~0.3.10",
+    "miniscript-type-analyzer": "~0.4.2",
     "node-persist": "^3.1.3",
     "open": "^8.2.1",
     "pacote": "^15.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lru-cache": "^7.14.1",
     "mkdirp": "^1.0.4",
     "monaco-textmate-provider": "^1.3.0",
-    "miniscript-type-analyzer": "~0.4.2",
+    "miniscript-type-analyzer": "~0.4.3",
     "node-persist": "^3.1.3",
     "open": "^8.2.1",
     "pacote": "^15.1.3",

--- a/src/web/extension/autocomplete/constants.ts
+++ b/src/web/extension/autocomplete/constants.ts
@@ -6,16 +6,10 @@ export const AVAILABLE_CONSTANTS = [
   'true',
   'false',
   'null',
-  'map',
-  'funcRef',
-  'list',
-  'number',
-  'string',
   'params',
   'globals',
   'locals',
-  'outer',
-  'self'
+  'outer'
 ] as const;
 
 export const getAvailableConstants = (

--- a/src/web/extension/helper/lookup-type.ts
+++ b/src/web/extension/helper/lookup-type.ts
@@ -113,6 +113,10 @@ export class LookupHelper {
       }
     }
 
+    for (const assignment of typeDoc.api.getAllIdentifier()) {
+      result.set(...assignment);
+    }
+
     return result;
   }
 

--- a/src/web/extension/helper/lookup-type.ts
+++ b/src/web/extension/helper/lookup-type.ts
@@ -9,6 +9,7 @@ import {
 } from 'miniscript-core';
 import {
   CompletionItem,
+  CompletionItemKind,
   IEntity
 } from 'miniscript-type-analyzer';
 import type {
@@ -76,6 +77,21 @@ export class LookupHelper {
     const typeDoc = typeManager.get(this.document.uri.fsPath);
     const result: Map<string, CompletionItem> = new Map();
     const scopeContext = typeDoc.getScopeContext(item.scope);
+
+    if (scopeContext.scope.isSelfAvailable()) {
+      result.set('self', {
+        kind: CompletionItemKind.Constant,
+        line: -1
+      });
+    }
+
+    if (scopeContext.scope.isSuperAvailable()) {
+      result.set('super', {
+        kind: CompletionItemKind.Constant,
+        line: -1
+      });
+    }
+
     const assignments = Array.from(
       scopeContext.scope.locals.getAllIdentifier().entries()
     )


### PR DESCRIPTION
Includes:
- add super keyword to type-analyzer
- fix member expression containing new unary when resolving type
- only use shallow copy when copying entity to avoid memory exhaustion for type-analyzer
- properly resolve members of scope variables and api definitions for type-analyzer