### PR TITLE
3.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1195,3 +1195,11 @@ All notable changes to this project will be documented in this file.
 
 - let type-analyzer resolve logical expressions as number
 - let type-analyzer set proper label for binary expression
+
+## [3.3.16] - 18.07.2024
+
+- keep multiline comments in devMode when beautifying
+- fix beautify regarding multiline comments
+- fix beautify when having multiple commands in one line via semicolon
+- fix signature parser for multiline comments
+- add support for envar, file and line in type-analyzer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.3.15",
+  "version": "3.3.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.3.15",
+      "version": "3.3.16",
       "dependencies": {
         "@babel/runtime": "^7.16.7",
         "@inquirer/core": "^1.0.1",
@@ -25,10 +25,10 @@
         "greyscript-core": "~1.7.0",
         "greyscript-interpreter": "~1.9.2",
         "greyscript-meta": "~4.0.8",
-        "greyscript-transpiler": "~0.8.3",
+        "greyscript-transpiler": "~0.9.0",
         "is-inside-container": "^1.0.0",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.5.4",
+        "miniscript-type-analyzer": "~0.6.0",
         "mkdirp": "^1.0.4",
         "monaco-textmate-provider": "^1.3.0",
         "node-persist": "^3.1.3",
@@ -5757,9 +5757,9 @@
       }
     },
     "node_modules/greybel-transpiler": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.7.3.tgz",
-      "integrity": "sha512-IKnymonnuPQF4a74yQlQacl593gxsSjsP2RIB9SpkCwgaLnSoYgpF+0rpVIDleIlu3jNQUHEv1iOod7tNScp1w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.8.0.tgz",
+      "integrity": "sha512-ynhDu7g/9B9g90VQZqy9wVIaHtbQZSSdppMQL+CXF525h2PWjHR1k6zKrhwji6tzWY/fbHE7Azq+H8PGVq2yLw==",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~1.7.0"
@@ -5791,12 +5791,12 @@
       }
     },
     "node_modules/greyscript-transpiler": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.8.3.tgz",
-      "integrity": "sha512-VS5fUTMbsKlIlMAQWBxxbMWlSF6XQkjwxpYdyOx2AWRXeyf+m2xOJ5i/BjxyBl7CwmpqEa6wplVzPtoPaqAQwA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.9.0.tgz",
+      "integrity": "sha512-qgLutkSohTcpUbttFr7El0FATsCew80T1ZrY8emD7eVvS9SVmoY8kzZhVSDmIq/g4ROxBbcMoQv7h3O6Al1Zzw==",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~2.7.3",
+        "greybel-transpiler": "~2.8.0",
         "greyscript-core": "~1.7.0"
       }
     },
@@ -6999,13 +6999,13 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
-      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.6.0.tgz",
+      "integrity": "sha512-nOC8y4YO2iBm7AeO5hxDoscFG3gXVPrHdcOwkf5ceGIYlArKEJPXtaQ6xuJ3aJqAvYbhjHsjLgsuPWBq4jS65w==",
       "dependencies": {
         "comment-parser": "^1.4.1",
+        "greybel-core": "~1.7.0",
         "meta-utils": "~2.4.6",
-        "miniscript-core": "^0.7.0",
         "object-code": "^1.3.3"
       }
     },
@@ -13786,9 +13786,9 @@
       }
     },
     "greybel-transpiler": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.7.3.tgz",
-      "integrity": "sha512-IKnymonnuPQF4a74yQlQacl593gxsSjsP2RIB9SpkCwgaLnSoYgpF+0rpVIDleIlu3jNQUHEv1iOod7tNScp1w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.8.0.tgz",
+      "integrity": "sha512-ynhDu7g/9B9g90VQZqy9wVIaHtbQZSSdppMQL+CXF525h2PWjHR1k6zKrhwji6tzWY/fbHE7Azq+H8PGVq2yLw==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~1.7.0"
@@ -13820,12 +13820,12 @@
       }
     },
     "greyscript-transpiler": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.8.3.tgz",
-      "integrity": "sha512-VS5fUTMbsKlIlMAQWBxxbMWlSF6XQkjwxpYdyOx2AWRXeyf+m2xOJ5i/BjxyBl7CwmpqEa6wplVzPtoPaqAQwA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.9.0.tgz",
+      "integrity": "sha512-qgLutkSohTcpUbttFr7El0FATsCew80T1ZrY8emD7eVvS9SVmoY8kzZhVSDmIq/g4ROxBbcMoQv7h3O6Al1Zzw==",
       "requires": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~2.7.3",
+        "greybel-transpiler": "~2.8.0",
         "greyscript-core": "~1.7.0"
       }
     },
@@ -14706,13 +14706,13 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
-      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.6.0.tgz",
+      "integrity": "sha512-nOC8y4YO2iBm7AeO5hxDoscFG3gXVPrHdcOwkf5ceGIYlArKEJPXtaQ6xuJ3aJqAvYbhjHsjLgsuPWBq4jS65w==",
       "requires": {
         "comment-parser": "^1.4.1",
+        "greybel-core": "~1.7.0",
         "meta-utils": "~2.4.6",
-        "miniscript-core": "^0.7.0",
         "object-code": "^1.3.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.3.15",
+  "version": "3.3.16",
   "engines": {
     "node": ">=18.17.0"
   },
@@ -39,12 +39,12 @@
     "greyscript-core": "~1.7.0",
     "greyscript-interpreter": "~1.9.2",
     "greyscript-meta": "~4.0.8",
-    "greyscript-transpiler": "~0.8.3",
+    "greyscript-transpiler": "~0.9.0",
     "is-inside-container": "^1.0.0",
     "lru-cache": "^7.14.1",
     "mkdirp": "^1.0.4",
     "monaco-textmate-provider": "^1.3.0",
-    "miniscript-type-analyzer": "~0.5.4",
+    "miniscript-type-analyzer": "~0.6.0",
     "node-persist": "^3.1.3",
     "open": "^8.2.1",
     "pacote": "^15.1.3",


### PR DESCRIPTION
Includes:
- keep multiline comments in devMode when beautifying
- fix beautify regarding multiline comments
- fix beautify when having multiple commands in one line via semicolon
- fix signature parser for multiline comments
- add support for envar, file and line in type-analyzer