### PR TITLE
3.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1233,3 +1233,7 @@ All notable changes to this project will be documented in this file.
 ## [3.4.2] - 01.08.2024
 
 - show proper error message when trying to call propery from null value instead of throwing ".getWithOrigin is not a function"
+
+## [3.4.3] - 05.08.2024
+
+- fix "Unexpected identifier 'assert'" error on newer node versions - related to [#212](https://github.com/ayecue/greybel-vs/issues/212) - thanks for reporting Pungent Bonfire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1236,4 +1236,4 @@ All notable changes to this project will be documented in this file.
 
 ## [3.4.3] - 05.08.2024
 
-- fix "Unexpected identifier 'assert'" error on newer node versions - related to [#212](https://github.com/ayecue/greybel-vs/issues/212) - thanks for reporting Pungent Bonfire
+- fix "Unexpected identifier 'assert'" error on newer node versions - related to [#212](https://github.com/ayecue/greybel-js/issues/212) - thanks for reporting Pungent Bonfire

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,15 +1,19 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env -S node --no-warnings --no-deprecation
 
 import { AnotherAnsiProvider, ColorType } from 'another-ansi';
 import { program } from 'commander';
 import pacote from 'pacote';
 import semver from 'semver';
 import open from 'open';
+import { createRequire } from 'node:module';
 
 import execute from '../out/execute.js';
 import build from '../out/build.js';
 import repl from '../out/repl.js';
-import packageJSON from '../package.json' assert { type: 'json' };
+
+// revisit once import type { 'json' } is supported by lts
+const require = createRequire(import.meta.url);
+const packageJSON = require('../package.json');
 
 const ansiProvider = new AnotherAnsiProvider();
 const engineVersion = packageJSON.engines.node;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "dependencies": {
         "@inquirer/core": "^1.0.1",
         "@inquirer/prompts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/src/execute/output.ts
+++ b/src/execute/output.ts
@@ -1,7 +1,6 @@
 import { AnotherAnsiProvider, ModifierType } from 'another-ansi';
 import ansiEscapes from 'ansi-escapes';
 import cliProgress from 'cli-progress';
-import cssColorNames from 'css-color-names/css-color-names.json' assert { type: 'json' };
 import {
   KeyEvent,
   OutputHandler,
@@ -9,6 +8,7 @@ import {
   UpdateOptions,
   VM
 } from 'greybel-interpreter';
+import { createRequire } from 'node:module';
 import readline from 'readline';
 import { Tag, TagRecordOpen, transform } from 'text-mesh-transformer';
 
@@ -17,6 +17,10 @@ import {
   customPassword as password
 } from '../helper/prompts.js';
 import { NodeJSKeyEvent, nodeJSKeyEventToKeyEvent } from './key-event.js';
+
+// revisit once import type { 'json' } is supported by lts
+const require = createRequire(import.meta.url);
+const cssColorNames = require('css-color-names/css-color-names.json');
 
 export const ansiProvider = new AnotherAnsiProvider();
 const hasOwnProperty = Object.prototype.hasOwnProperty;


### PR DESCRIPTION
Includes
- fix "Unexpected identifier 'assert'" error on newer node versions - related to [#212](https://github.com/ayecue/greybel-js/issues/212)