### PR TITLE
3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1289,3 +1289,8 @@ All notable changes to this project will be documented in this file.
 - fix conflict with comments on beautify - related to [#53](https://github.com/ayecue/miniscript-vs/issues/53) - thanks for reporting to [@Xisec](https://github.com/Xisec)
 - fix edge cases for variable optimizations on uglify
 - fix edge cases for literal optimizations on uglify
+
+## [3.5.1] - 16.09.2024
+
+- fix globals shorthand identifier not getting injected when no literal optimization were happening - related to [#157](https://github.com/ayecue/greybel-js/issues/157) - thanks for reporting to [@smiley8D](https://github.com/smiley8D)
+- fix behaviour of import op in runtime which caused it's payload to be called every time it was imported, instead it's only getting executed once now - related to [#222](https://github.com/ayecue/greybel-js/issues/222) - thanks for reporting to [@smiley8D](https://github.com/smiley8D)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "greyscript-core": "~2.1.1",
         "greyscript-interpreter": "~2.1.1",
         "greyscript-meta": "~4.0.11",
-        "greyscript-transpiler": "~1.2.2",
+        "greyscript-transpiler": "~1.2.3",
         "is-inside-container": "^1.0.0",
         "lru-cache": "^7.14.1",
         "miniscript-type-analyzer": "~0.9.0",
@@ -3752,9 +3752,9 @@
       }
     },
     "node_modules/greybel-transpiler": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.2.tgz",
-      "integrity": "sha512-lbOgZ1l/PVINYpmL2iV8jZkxgiFH4Q8fZRDKs4xBa9WdilNSurTrsRrc7l/Qm5+EN7ojqxlg6hjNLu73jOiT2w==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.3.tgz",
+      "integrity": "sha512-qocISjC/W79I09t/9HLULhZ7UjgokPDM9XpCF9B3fbicpk6aikoDnezKJuNnIfQe7w63aMEAZRDHp6/tdutt9w==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -3790,13 +3790,13 @@
       }
     },
     "node_modules/greyscript-transpiler": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.2.tgz",
-      "integrity": "sha512-ipTtDKcIiBjH/2EdTAKyKOJ+O0PrRAyd4x1D8pZfKM0+gQDFIw19Y3omcdvSJCKKDkHO4/MmpZV0DUsmJp2q9Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.3.tgz",
+      "integrity": "sha512-o6u0n2s5EyLg0471wYdP/j8pdigoTg6rHf/8QjvYqdw4cszkwhggYzN6oABo/ZySdYtoBiCoq2fjQ16JaQvr9w==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.2.2",
+        "greybel-transpiler": "~3.2.3",
         "greyscript-core": "~2.1.1"
       }
     },
@@ -9879,9 +9879,9 @@
       }
     },
     "greybel-transpiler": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.2.tgz",
-      "integrity": "sha512-lbOgZ1l/PVINYpmL2iV8jZkxgiFH4Q8fZRDKs4xBa9WdilNSurTrsRrc7l/Qm5+EN7ojqxlg6hjNLu73jOiT2w==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.3.tgz",
+      "integrity": "sha512-qocISjC/W79I09t/9HLULhZ7UjgokPDM9XpCF9B3fbicpk6aikoDnezKJuNnIfQe7w63aMEAZRDHp6/tdutt9w==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~2.1.0"
@@ -9913,12 +9913,12 @@
       }
     },
     "greyscript-transpiler": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.2.tgz",
-      "integrity": "sha512-ipTtDKcIiBjH/2EdTAKyKOJ+O0PrRAyd4x1D8pZfKM0+gQDFIw19Y3omcdvSJCKKDkHO4/MmpZV0DUsmJp2q9Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.3.tgz",
+      "integrity": "sha512-o6u0n2s5EyLg0471wYdP/j8pdigoTg6rHf/8QjvYqdw4cszkwhggYzN6oABo/ZySdYtoBiCoq2fjQ16JaQvr9w==",
       "requires": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.2.2",
+        "greybel-transpiler": "~3.2.3",
         "greyscript-core": "~2.1.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "dependencies": {
         "@inquirer/core": "^1.0.1",
         "@inquirer/prompts": "^1.0.0",
@@ -20,12 +20,12 @@
         "crlf-normalize": "^1.0.20",
         "css-color-names": "^1.0.1",
         "greybel-agent": "~1.8.1",
-        "greybel-gh-mock-intrinsics": "~5.1.0",
-        "greybel-intrinsics": "~5.1.0",
+        "greybel-gh-mock-intrinsics": "~5.1.1",
+        "greybel-intrinsics": "~5.1.1",
         "greyscript-core": "~2.1.1",
-        "greyscript-interpreter": "~2.1.0",
+        "greyscript-interpreter": "~2.1.1",
         "greyscript-meta": "~4.0.11",
-        "greyscript-transpiler": "~1.2.1",
+        "greyscript-transpiler": "~1.2.2",
         "is-inside-container": "^1.0.0",
         "lru-cache": "^7.14.1",
         "miniscript-type-analyzer": "~0.9.0",
@@ -3707,20 +3707,20 @@
       }
     },
     "node_modules/greybel-gh-mock-intrinsics": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.1.0.tgz",
-      "integrity": "sha512-xo7RexDIZwhsHJPxy9D8fDI6hbUYYMZ5QjJBBYstAkPK3TH2pxHIkaw2zTi3C8EdRC7AbyY3XtzhZ1jt2Cj3pA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.1.1.tgz",
+      "integrity": "sha512-6ZVfaSkGyVXYtpCcOyrEpNnEfN0sWxlOKbmE9ZvpWVweLB5FgKkWK5AIII6EMpiRyiZvkDiU2rOgExSoA3XMdg==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "greybel-mock-environment": "~2.4.26",
-        "greyscript-interpreter": "~2.1.0"
+        "greyscript-interpreter": "~2.1.1"
       }
     },
     "node_modules/greybel-interpreter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.0.tgz",
-      "integrity": "sha512-3CVwdCdTGe/GA0tuTj7fZwFL8gALzYuI3GuuyvWhV5jgMG7pSSbZJK5fiCPCmU5RHcLxYlgm4upKtpoCrORd8A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.1.tgz",
+      "integrity": "sha512-TFMqp3rbTC890sntxH/wH1ksOfM6fnj3cxzX8zAizYIRRTYCM3TV/xKEEdW1pUeRhTzJYtXS8BtNJNQ9o6/h+Q==",
       "license": "MIT",
       "dependencies": {
         "greybel-core": "~2.1.1",
@@ -3729,12 +3729,12 @@
       }
     },
     "node_modules/greybel-intrinsics": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.1.0.tgz",
-      "integrity": "sha512-WG69zkQIQYit6zuZrI4ASfA2OiCspPgHGcKLDTRF5iNszQz0QHKECFTnJa3OiDTVqioO3fytsJGLF8ywx3+1TA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.1.1.tgz",
+      "integrity": "sha512-clr4g/5uikzHd4eanKPOba4xR8FuGHjzL0QXtXivT06m0q+sMRo2Jq7K65VcOnwyVHBN15mgp63iDdivQEsfwg==",
       "license": "MIT",
       "dependencies": {
-        "greyscript-interpreter": "~2.1.0",
+        "greyscript-interpreter": "~2.1.1",
         "xregexp": "^5.1.1"
       }
     },
@@ -3752,9 +3752,9 @@
       }
     },
     "node_modules/greybel-transpiler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.1.tgz",
-      "integrity": "sha512-c7oKGOFypxfhRgB4wyHP9ZG8AQbqMsr2yo+ddBv1gN34PowawkJhAKf/Ea9Xou/mSXu1ov1yO7qTvn41Hvjnkw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.2.tgz",
+      "integrity": "sha512-lbOgZ1l/PVINYpmL2iV8jZkxgiFH4Q8fZRDKs4xBa9WdilNSurTrsRrc7l/Qm5+EN7ojqxlg6hjNLu73jOiT2w==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -3771,12 +3771,12 @@
       }
     },
     "node_modules/greyscript-interpreter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.0.tgz",
-      "integrity": "sha512-DA1+ZW/eE3BJb6jH+j8UFNfBU6J6nsvVReuVzECt64WIqQDYbcJY2fspvhoWWoijzDevGnkUJEfcDDFZpMYO8Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.1.tgz",
+      "integrity": "sha512-tcauNr2lEaPoOPuAekisOAROqOG0C3iLjNxBoucRdnLRyiNnyqya0Z6r5U2IksVSZEhh8RBmEyNxQA81FAIb+w==",
       "license": "MIT",
       "dependencies": {
-        "greybel-interpreter": "~5.1.0",
+        "greybel-interpreter": "~5.1.1",
         "greyscript-core": "~2.1.1"
       }
     },
@@ -3790,13 +3790,13 @@
       }
     },
     "node_modules/greyscript-transpiler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.1.tgz",
-      "integrity": "sha512-isnMvMabWtLzn+ppYqzQmWyaFyffE4a9rqo0t+1cYvJ5Z6+4mhh78+REkHYxM82A25g241rPENfmdZCGezAz2A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.2.tgz",
+      "integrity": "sha512-ipTtDKcIiBjH/2EdTAKyKOJ+O0PrRAyd4x1D8pZfKM0+gQDFIw19Y3omcdvSJCKKDkHO4/MmpZV0DUsmJp2q9Q==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.2.1",
+        "greybel-transpiler": "~3.2.2",
         "greyscript-core": "~2.1.1"
       }
     },
@@ -9838,19 +9838,19 @@
       }
     },
     "greybel-gh-mock-intrinsics": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.1.0.tgz",
-      "integrity": "sha512-xo7RexDIZwhsHJPxy9D8fDI6hbUYYMZ5QjJBBYstAkPK3TH2pxHIkaw2zTi3C8EdRC7AbyY3XtzhZ1jt2Cj3pA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.1.1.tgz",
+      "integrity": "sha512-6ZVfaSkGyVXYtpCcOyrEpNnEfN0sWxlOKbmE9ZvpWVweLB5FgKkWK5AIII6EMpiRyiZvkDiU2rOgExSoA3XMdg==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-mock-environment": "~2.4.26",
-        "greyscript-interpreter": "~2.1.0"
+        "greyscript-interpreter": "~2.1.1"
       }
     },
     "greybel-interpreter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.0.tgz",
-      "integrity": "sha512-3CVwdCdTGe/GA0tuTj7fZwFL8gALzYuI3GuuyvWhV5jgMG7pSSbZJK5fiCPCmU5RHcLxYlgm4upKtpoCrORd8A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.1.tgz",
+      "integrity": "sha512-TFMqp3rbTC890sntxH/wH1ksOfM6fnj3cxzX8zAizYIRRTYCM3TV/xKEEdW1pUeRhTzJYtXS8BtNJNQ9o6/h+Q==",
       "requires": {
         "greybel-core": "~2.1.1",
         "hyperid": "^3.2.0",
@@ -9858,11 +9858,11 @@
       }
     },
     "greybel-intrinsics": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.1.0.tgz",
-      "integrity": "sha512-WG69zkQIQYit6zuZrI4ASfA2OiCspPgHGcKLDTRF5iNszQz0QHKECFTnJa3OiDTVqioO3fytsJGLF8ywx3+1TA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.1.1.tgz",
+      "integrity": "sha512-clr4g/5uikzHd4eanKPOba4xR8FuGHjzL0QXtXivT06m0q+sMRo2Jq7K65VcOnwyVHBN15mgp63iDdivQEsfwg==",
       "requires": {
-        "greyscript-interpreter": "~2.1.0",
+        "greyscript-interpreter": "~2.1.1",
         "xregexp": "^5.1.1"
       }
     },
@@ -9879,9 +9879,9 @@
       }
     },
     "greybel-transpiler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.1.tgz",
-      "integrity": "sha512-c7oKGOFypxfhRgB4wyHP9ZG8AQbqMsr2yo+ddBv1gN34PowawkJhAKf/Ea9Xou/mSXu1ov1yO7qTvn41Hvjnkw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.2.tgz",
+      "integrity": "sha512-lbOgZ1l/PVINYpmL2iV8jZkxgiFH4Q8fZRDKs4xBa9WdilNSurTrsRrc7l/Qm5+EN7ojqxlg6hjNLu73jOiT2w==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~2.1.0"
@@ -9896,11 +9896,11 @@
       }
     },
     "greyscript-interpreter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.0.tgz",
-      "integrity": "sha512-DA1+ZW/eE3BJb6jH+j8UFNfBU6J6nsvVReuVzECt64WIqQDYbcJY2fspvhoWWoijzDevGnkUJEfcDDFZpMYO8Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.1.tgz",
+      "integrity": "sha512-tcauNr2lEaPoOPuAekisOAROqOG0C3iLjNxBoucRdnLRyiNnyqya0Z6r5U2IksVSZEhh8RBmEyNxQA81FAIb+w==",
       "requires": {
-        "greybel-interpreter": "~5.1.0",
+        "greybel-interpreter": "~5.1.1",
         "greyscript-core": "~2.1.1"
       }
     },
@@ -9913,12 +9913,12 @@
       }
     },
     "greyscript-transpiler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.1.tgz",
-      "integrity": "sha512-isnMvMabWtLzn+ppYqzQmWyaFyffE4a9rqo0t+1cYvJ5Z6+4mhh78+REkHYxM82A25g241rPENfmdZCGezAz2A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.2.tgz",
+      "integrity": "sha512-ipTtDKcIiBjH/2EdTAKyKOJ+O0PrRAyd4x1D8pZfKM0+gQDFIw19Y3omcdvSJCKKDkHO4/MmpZV0DUsmJp2q9Q==",
       "requires": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.2.1",
+        "greybel-transpiler": "~3.2.2",
         "greyscript-core": "~2.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "greyscript-core": "~2.1.1",
     "greyscript-interpreter": "~2.1.1",
     "greyscript-meta": "~4.0.11",
-    "greyscript-transpiler": "~1.2.2",
+    "greyscript-transpiler": "~1.2.3",
     "is-inside-container": "^1.0.0",
     "lru-cache": "^7.14.1",
     "miniscript-type-analyzer": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "engines": {
     "node": ">=18.17.0"
   },
@@ -34,12 +34,12 @@
     "crlf-normalize": "^1.0.20",
     "css-color-names": "^1.0.1",
     "greybel-agent": "~1.8.1",
-    "greybel-gh-mock-intrinsics": "~5.1.0",
-    "greybel-intrinsics": "~5.1.0",
+    "greybel-gh-mock-intrinsics": "~5.1.1",
+    "greybel-intrinsics": "~5.1.1",
     "greyscript-core": "~2.1.1",
-    "greyscript-interpreter": "~2.1.0",
+    "greyscript-interpreter": "~2.1.1",
     "greyscript-meta": "~4.0.11",
-    "greyscript-transpiler": "~1.2.1",
+    "greyscript-transpiler": "~1.2.2",
     "is-inside-container": "^1.0.0",
     "lru-cache": "^7.14.1",
     "miniscript-type-analyzer": "~0.9.0",


### PR DESCRIPTION
Includes
- fix globals shorthand identifier not getting injected when no literal optimization were happening - related to [#157](https://github.com/ayecue/greybel-js/issues/157)
- fix behaviour of import op in runtime which caused it's payload to be called every time it was imported, instead it's only getting executed once now - related to [#222](https://github.com/ayecue/greybel-js/issues/222)