### PR TITLE
3.6.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1529,3 +1529,8 @@ All notable changes to this project will be documented in this file.
 ## [3.6.14] - 04.05.2025
 
 - use compression for large message related to in-game debugging
+
+## [3.6.15] - 04.05.2025
+
+- wait for context disposal when stopping in order to get process properly killed in game
+- listen for exit, SIGINT, SIGUSR1, SIGUSR2, SIGTERM and uncaughtException event to dispose context 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.6.14",
+  "version": "3.6.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.6.14",
+      "version": "3.6.15",
       "dependencies": {
         "@inquirer/core": "^10.1.7",
         "@inquirer/prompts": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.6.14",
+  "version": "3.6.15",
   "engines": {
     "node": ">=20.17.0"
   },


### PR DESCRIPTION
Includes:
- wait for context disposal when stopping in order to get process properly killed in game
- listen for exit, SIGINT, SIGUSR1, SIGUSR2, SIGTERM and uncaughtException event to dispose context 