### PR TITLE
3.6.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1579,3 +1579,7 @@ All notable changes to this project will be documented in this file.
 
 - added option to define additional file extensions considered during file extension auto-resolution - thanks for the suggestion to [@EntitySeaker](https://github.com/EntitySeaker)
 - added option to define the name of the main output file - thanks for the suggestion to [@EntitySeaker](https://github.com/EntitySeaker)
+
+## [3.6.25] - 17.05.2025
+
+- run message handling in message-hook on the Unity main thread to prevent Mono-related crashes - fixes rare, seemingly random crashes caused by background task execution

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The message-hook agent allows you to send messages to the game server through th
 ##### BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/531bb2b769be2c7ac78ddd488b90b4ae8aed7b3c/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/7db7f5c99659598a42001b51f5a7b397987eea18/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`
@@ -134,7 +134,7 @@ The message-hook agent allows you to send messages to the game server through th
 ##### BepInEx 6.x.x
 1. **Download BepInEx 6.x.x**: [BepInEx version 6.0.0-pre.2 Unity.Mono](https://github.com/BepInEx/BepInEx/releases/tag/v6.0.0-pre.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/master/articles/user_guide/installation/unity_mono.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/531bb2b769be2c7ac78ddd488b90b4ae8aed7b3c/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/7db7f5c99659598a42001b51f5a7b397987eea18/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.6.24",
+  "version": "3.6.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.6.24",
+      "version": "3.6.25",
       "dependencies": {
         "@inquirer/core": "^10.1.7",
         "@inquirer/prompts": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.6.24",
+  "version": "3.6.25",
   "engines": {
     "node": ">=20.17.0"
   },

--- a/src/helper/version-manager.ts
+++ b/src/helper/version-manager.ts
@@ -18,7 +18,7 @@ interface HealthCheckResult {
 }
 
 export class VersionManager {
-  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.9';
+  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.10';
   static RESOURCE_LINK: string = 'https://github.com/ayecue/greybel-vs?tab=readme-ov-file#message-hook';
   
   private static _notificationInterval: number = 1000 * 60 * 60; // 1 hours


### PR DESCRIPTION
Includes:
- run message handling in message-hook on the Unity main thread to prevent Mono-related crashes - fixes rare, seemingly random crashes caused by background task execution