### PR TITLE
3.6.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1656,3 +1656,9 @@ All notable changes to this project will be documented in this file.
 
 - assume self type correctly when used in arguments and context is available (related to type analyser)
 - auto create map type if path does not yet have a map defined via virtual properties (related to type analyser)
+
+## [3.6.41] - 10.08.2025
+
+- JSDoc arguments aren't applied anymore by position but rather by their name (related to type analyser)
+- fix language server crash on invalid syntax in assignment statement (related to type analyser)
+- skip operation in case of missing metadata (requires message-hook plugin to be updated)

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ## BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/8d080256b2f73177b793656159d48075f81d1757/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/5f6b493ce6e213c261fe64bf01628702fc45258c/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`
@@ -459,7 +459,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ## BepInEx 6.x.x
 1. **Download BepInEx 6.x.x**: [BepInEx version 6.0.0-pre.2 Unity.Mono](https://github.com/BepInEx/BepInEx/releases/tag/v6.0.0-pre.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/master/articles/user_guide/installation/unity_mono.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/8d080256b2f73177b793656159d48075f81d1757/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/5f6b493ce6e213c261fe64bf01628702fc45258c/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.6.40",
+  "version": "3.6.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.6.40",
+      "version": "3.6.41",
       "dependencies": {
         "@inquirer/core": "^10.1.7",
         "@inquirer/prompts": "^7.3.2",
@@ -22,7 +22,7 @@
         "glob": "^11.0.1",
         "greybel-gh-mock-intrinsics": "~5.5.12",
         "greybel-intrinsics": "~5.5.5",
-        "greybel-type-analyzer": "~1.0.9",
+        "greybel-type-analyzer": "~1.0.11",
         "greyhack-message-hook-client": "~0.6.8",
         "greyscript-core": "~2.5.5",
         "greyscript-interpreter": "~2.5.4",
@@ -4039,10 +4039,10 @@
       }
     },
     "node_modules/greybel-type-analyzer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.9.tgz",
-      "integrity": "sha512-nPFLtdBsIFJjkQHwkpzzumDVpb/xEyFGIZMEwHmS1JnEkxB2HCkCpJYWxo4eq5ZrXtqvODTF4zEUFG9tzYBU8A==",
-      "license": "ISC",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.11.tgz",
+      "integrity": "sha512-bFdaAOnibh7gZRmlVeNl/YbJt856DuGpSuNuwDI4TpZx6UUIP84AKnYYdA8QWRtMDOhKLtimpdqO8RFeLfZpRA==",
+      "license": "MIT",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "greybel-core": "~2.5.2",
@@ -9621,9 +9621,9 @@
       }
     },
     "greybel-type-analyzer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.9.tgz",
-      "integrity": "sha512-nPFLtdBsIFJjkQHwkpzzumDVpb/xEyFGIZMEwHmS1JnEkxB2HCkCpJYWxo4eq5ZrXtqvODTF4zEUFG9tzYBU8A==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.11.tgz",
+      "integrity": "sha512-bFdaAOnibh7gZRmlVeNl/YbJt856DuGpSuNuwDI4TpZx6UUIP84AKnYYdA8QWRtMDOhKLtimpdqO8RFeLfZpRA==",
       "requires": {
         "comment-parser": "^1.4.1",
         "greybel-core": "~2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.6.40",
+  "version": "3.6.41",
   "engines": {
     "node": ">=20.17.0"
   },
@@ -42,7 +42,7 @@
     "greyscript-meta": "~4.3.2",
     "greyscript-transpiler": "~1.8.2",
     "lru-cache": "^11.0.2",
-    "greybel-type-analyzer": "~1.0.9",
+    "greybel-type-analyzer": "~1.0.11",
     "mkdirp": "^3.0.1",
     "monaco-textmate-provider": "^1.4.0",
     "node-persist": "^4.0.4",


### PR DESCRIPTION
Includes
- JSDoc arguments aren't applied anymore by position but rather by their name (related to type analyser)
- fix language server crash on invalid syntax in assignment statement (related to type analyser)
- skip operation in case of missing metadata (requires message-hook plugin to be updated)