### PR TITLE
3.6.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1662,3 +1662,8 @@ All notable changes to this project will be documented in this file.
 - JSDoc arguments aren't applied anymore by position but rather by their name (related to type analyser)
 - fix language server crash on invalid syntax in assignment statement (related to type analyser)
 - skip operation in case of missing metadata (requires message-hook plugin to be updated)
+
+## [3.6.42] - 10.08.2025
+
+- allow duplicate class names, properties will be merged if there are any duplicates (related to type analyser)
+- fix language server crash on path generation when components are not matching assumed usage (related to type analyser)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.6.41",
+  "version": "3.6.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.6.41",
+      "version": "3.6.42",
       "dependencies": {
         "@inquirer/core": "^10.1.7",
         "@inquirer/prompts": "^7.3.2",
@@ -22,7 +22,7 @@
         "glob": "^11.0.1",
         "greybel-gh-mock-intrinsics": "~5.5.12",
         "greybel-intrinsics": "~5.5.5",
-        "greybel-type-analyzer": "~1.0.11",
+        "greybel-type-analyzer": "~1.0.13",
         "greyhack-message-hook-client": "~0.6.8",
         "greyscript-core": "~2.5.5",
         "greyscript-interpreter": "~2.5.4",
@@ -4039,9 +4039,9 @@
       }
     },
     "node_modules/greybel-type-analyzer": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.11.tgz",
-      "integrity": "sha512-bFdaAOnibh7gZRmlVeNl/YbJt856DuGpSuNuwDI4TpZx6UUIP84AKnYYdA8QWRtMDOhKLtimpdqO8RFeLfZpRA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.13.tgz",
+      "integrity": "sha512-znOVTANQpU3mMa9eioqlPOAJ01QX5ZfKpRmMVIlgCMHhCrhAFXGhtzo4RWjkwU60rN3E9T0jpaZmMs2VQW8x5Q==",
       "license": "MIT",
       "dependencies": {
         "comment-parser": "^1.4.1",
@@ -9621,9 +9621,9 @@
       }
     },
     "greybel-type-analyzer": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.11.tgz",
-      "integrity": "sha512-bFdaAOnibh7gZRmlVeNl/YbJt856DuGpSuNuwDI4TpZx6UUIP84AKnYYdA8QWRtMDOhKLtimpdqO8RFeLfZpRA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/greybel-type-analyzer/-/greybel-type-analyzer-1.0.13.tgz",
+      "integrity": "sha512-znOVTANQpU3mMa9eioqlPOAJ01QX5ZfKpRmMVIlgCMHhCrhAFXGhtzo4RWjkwU60rN3E9T0jpaZmMs2VQW8x5Q==",
       "requires": {
         "comment-parser": "^1.4.1",
         "greybel-core": "~2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.6.41",
+  "version": "3.6.42",
   "engines": {
     "node": ">=20.17.0"
   },
@@ -42,7 +42,7 @@
     "greyscript-meta": "~4.3.2",
     "greyscript-transpiler": "~1.8.2",
     "lru-cache": "^11.0.2",
-    "greybel-type-analyzer": "~1.0.11",
+    "greybel-type-analyzer": "~1.0.13",
     "mkdirp": "^3.0.1",
     "monaco-textmate-provider": "^1.4.0",
     "node-persist": "^4.0.4",


### PR DESCRIPTION
Includes:
- allow duplicate class names, properties will be merged if there are any duplicates (related to type analyser)
- fix language server crash on path generation when components are not matching assumed usage (related to type analyser)