### PR TITLE
3.6.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1685,3 +1685,7 @@ All notable changes to this project will be documented in this file.
 ## [3.6.46] - 20.08.2025
 
 - improve transpiler to use 1/0 instead of true/false constant if using default/uglify mode
+
+## [3.6.47] - 22.08.2025
+
+- improve transpiler module wrapper approach, properly handles now if an export is not defined in a module - related to [#307](https://github.com/ayecue/greybel-js/issues/307) - thanks for reporting to [@M3rluzzo](https://github.com/M3rluzzo)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.6.45",
+  "version": "3.6.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.6.45",
+      "version": "3.6.47",
       "dependencies": {
         "@inquirer/core": "^10.1.7",
         "@inquirer/prompts": "^7.3.2",
@@ -27,7 +27,7 @@
         "greyscript-core": "~2.6.0",
         "greyscript-interpreter": "~2.6.0",
         "greyscript-meta": "~4.3.2",
-        "greyscript-transpiler": "~1.9.0",
+        "greyscript-transpiler": "~1.9.1",
         "lru-cache": "^11.0.2",
         "mkdirp": "^3.0.1",
         "monaco-textmate-provider": "^1.4.0",
@@ -4029,9 +4029,9 @@
       }
     },
     "node_modules/greybel-transpiler": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.8.0.tgz",
-      "integrity": "sha512-Tf16UtauN0UnvZy/P04ZZlmL8yifkxt8MInK1XTtlHA6hQ0CrpAMnhg5jNARarsDDW3ygCsKk1f+AbpawtW1UA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.8.1.tgz",
+      "integrity": "sha512-90lVlprFMkZKaJq6gJKc/m9snkToa+2MPhnugJcN7lNs4fhr/6OQpSA4Zw6ReNF+EENfPlMechda1RlvS0d7iQ==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -4087,13 +4087,13 @@
       }
     },
     "node_modules/greyscript-transpiler": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.9.0.tgz",
-      "integrity": "sha512-uMd/EpaxNNM3qC0Ky9CsVpxCvSBlqROMLbjNqXsaNg0XIIJLm1I04aPbUhxv+eysCiz6klSYoXvSW8NdJvH4WA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.9.1.tgz",
+      "integrity": "sha512-P37RkjVS4PSg8G15TpfpTLwZ4xvRGQUvZLAB+HnEhSRoZ/6/IipTkHLgVNENPrMeu4CFmFQRfbnnJbhaebJ4dw==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.8.0",
+        "greybel-transpiler": "~3.8.1",
         "greyscript-core": "~2.6.0"
       }
     },
@@ -9612,9 +9612,9 @@
       }
     },
     "greybel-transpiler": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.8.0.tgz",
-      "integrity": "sha512-Tf16UtauN0UnvZy/P04ZZlmL8yifkxt8MInK1XTtlHA6hQ0CrpAMnhg5jNARarsDDW3ygCsKk1f+AbpawtW1UA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.8.1.tgz",
+      "integrity": "sha512-90lVlprFMkZKaJq6gJKc/m9snkToa+2MPhnugJcN7lNs4fhr/6OQpSA4Zw6ReNF+EENfPlMechda1RlvS0d7iQ==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~2.6.0"
@@ -9664,12 +9664,12 @@
       }
     },
     "greyscript-transpiler": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.9.0.tgz",
-      "integrity": "sha512-uMd/EpaxNNM3qC0Ky9CsVpxCvSBlqROMLbjNqXsaNg0XIIJLm1I04aPbUhxv+eysCiz6klSYoXvSW8NdJvH4WA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.9.1.tgz",
+      "integrity": "sha512-P37RkjVS4PSg8G15TpfpTLwZ4xvRGQUvZLAB+HnEhSRoZ/6/IipTkHLgVNENPrMeu4CFmFQRfbnnJbhaebJ4dw==",
       "requires": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.8.0",
+        "greybel-transpiler": "~3.8.1",
         "greyscript-core": "~2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.6.46",
+  "version": "3.6.47",
   "engines": {
     "node": ">=20.17.0"
   },
@@ -40,7 +40,7 @@
     "greyscript-core": "~2.6.0",
     "greyscript-interpreter": "~2.6.0",
     "greyscript-meta": "~4.3.2",
-    "greyscript-transpiler": "~1.9.0",
+    "greyscript-transpiler": "~1.9.1",
     "lru-cache": "^11.0.2",
     "greybel-type-analyzer": "~1.1.1",
     "mkdirp": "^3.0.1",


### PR DESCRIPTION
Includes:
- improve transpiler module wrapper approach, properly handles now if an export is not defined in a module - related to [#307](https://github.com/ayecue/greybel-js/issues/307)