### PR TITLE
3.6.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1689,3 +1689,8 @@ All notable changes to this project will be documented in this file.
 ## [3.6.47] - 22.08.2025
 
 - improve transpiler module wrapper approach, properly handles now if an export is not defined in a module - related to [#307](https://github.com/ayecue/greybel-js/issues/307) - thanks for reporting to [@M3rluzzo](https://github.com/M3rluzzo)
+
+## [3.6.48] - 23.08.2025
+
+- allow overidding of globals, locals and outer in interpreter runtime
+- remove check on map.push in case of already existing key to emulate in-game behaviour

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.6.47",
+  "version": "3.6.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.6.47",
+      "version": "3.6.48",
       "dependencies": {
         "@inquirer/core": "^10.1.7",
         "@inquirer/prompts": "^7.3.2",
@@ -20,12 +20,12 @@
         "crlf-normalize": "^1.0.20",
         "css-color-names": "^1.0.1",
         "glob": "^11.0.1",
-        "greybel-gh-mock-intrinsics": "~5.6.0",
-        "greybel-intrinsics": "~5.6.0",
+        "greybel-gh-mock-intrinsics": "~5.6.1",
+        "greybel-intrinsics": "~5.6.1",
         "greybel-type-analyzer": "~1.1.1",
         "greyhack-message-hook-client": "~0.6.10",
         "greyscript-core": "~2.6.0",
-        "greyscript-interpreter": "~2.6.0",
+        "greyscript-interpreter": "~2.6.1",
         "greyscript-meta": "~4.3.2",
         "greyscript-transpiler": "~1.9.1",
         "lru-cache": "^11.0.2",
@@ -3976,20 +3976,20 @@
       }
     },
     "node_modules/greybel-gh-mock-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-rIvzV4rS/WlgT1BTK6oD8vWM6m30YUeEocUOaOIUP5oFu0KeqXh+rZAz0DdZ9odGrozG8zCu/tN3JTvejb5PHg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-/KKqHaOlqEL4Xr5f3EYFDTIdjQ2fs8x41eeEb/FX9IUHQ63VCb7Ns7lmavtPY1HpMXtZW3MJmt8Azsui70AZQg==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "greybel-mock-environment": "~2.4.38",
-        "greyscript-interpreter": "~2.6.0"
+        "greyscript-interpreter": "~2.6.1"
       }
     },
     "node_modules/greybel-interpreter": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.0.tgz",
-      "integrity": "sha512-9JluhLd7Vl9tek9yqqiIhfmqoixoyXmVrSkOzTKb8bfgyKLc9Gnf4+WpCAXlaD2feEs05ereh2VUpDiQCMJQQw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.1.tgz",
+      "integrity": "sha512-wb4JU2cEhB1aZrU8jEygCgX0+jk0HZTOEIngc8ApseesSvuPia4Yy1YrGoFydE7XFGKVc6L+fhEDwrT0zG7f3Q==",
       "license": "MIT",
       "dependencies": {
         "greybel-core": "~2.6.0",
@@ -3999,12 +3999,12 @@
       }
     },
     "node_modules/greybel-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-VE4SOlD3sMa3X/Y4DHJycJa7EB6rGLlHggJ6vrimx44pPgifdhzNhMQKWX+HzjhI8F18eSoqrh2q+apUdh0Yeg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-Lgj2TZc2BqzB8SsUm6v9eHGgAZQfgsCs1Uwhh2gIRD7Ts5RqWAN+RQDm2iYme/QVgoBwMwd6YGEFkIHBCdfTDg==",
       "license": "MIT",
       "dependencies": {
-        "greyscript-interpreter": "~2.6.0",
+        "greyscript-interpreter": "~2.6.1",
         "long": "^5.2.4",
         "xregexp": "^5.1.1"
       }
@@ -4068,12 +4068,12 @@
       }
     },
     "node_modules/greyscript-interpreter": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.0.tgz",
-      "integrity": "sha512-mqUSkMwWiCxbKPpIswj14VNFctgswO7wDq55dvVcDSTSSUi0DNnZtffOSyUyKzFzH5BrJF3zt05p67dHRYqqdQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.1.tgz",
+      "integrity": "sha512-YgRyN2d4IH5Kz2KiDsRYYGqi5gZoPuCxZAVHF/Z9hRt78qvqy49AwR6jsRWu8SXKLGHxFYZgFq2ak1QUdhbqAg==",
       "license": "MIT",
       "dependencies": {
-        "greybel-interpreter": "~5.6.0",
+        "greybel-interpreter": "~5.6.1",
         "greyscript-core": "~2.6.0"
       }
     },
@@ -9562,19 +9562,19 @@
       }
     },
     "greybel-gh-mock-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-rIvzV4rS/WlgT1BTK6oD8vWM6m30YUeEocUOaOIUP5oFu0KeqXh+rZAz0DdZ9odGrozG8zCu/tN3JTvejb5PHg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-/KKqHaOlqEL4Xr5f3EYFDTIdjQ2fs8x41eeEb/FX9IUHQ63VCb7Ns7lmavtPY1HpMXtZW3MJmt8Azsui70AZQg==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-mock-environment": "~2.4.38",
-        "greyscript-interpreter": "~2.6.0"
+        "greyscript-interpreter": "~2.6.1"
       }
     },
     "greybel-interpreter": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.0.tgz",
-      "integrity": "sha512-9JluhLd7Vl9tek9yqqiIhfmqoixoyXmVrSkOzTKb8bfgyKLc9Gnf4+WpCAXlaD2feEs05ereh2VUpDiQCMJQQw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.1.tgz",
+      "integrity": "sha512-wb4JU2cEhB1aZrU8jEygCgX0+jk0HZTOEIngc8ApseesSvuPia4Yy1YrGoFydE7XFGKVc6L+fhEDwrT0zG7f3Q==",
       "requires": {
         "greybel-core": "~2.6.0",
         "hyperid": "^3.2.0",
@@ -9583,11 +9583,11 @@
       }
     },
     "greybel-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-VE4SOlD3sMa3X/Y4DHJycJa7EB6rGLlHggJ6vrimx44pPgifdhzNhMQKWX+HzjhI8F18eSoqrh2q+apUdh0Yeg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-Lgj2TZc2BqzB8SsUm6v9eHGgAZQfgsCs1Uwhh2gIRD7Ts5RqWAN+RQDm2iYme/QVgoBwMwd6YGEFkIHBCdfTDg==",
       "requires": {
-        "greyscript-interpreter": "~2.6.0",
+        "greyscript-interpreter": "~2.6.1",
         "long": "^5.2.4",
         "xregexp": "^5.1.1"
       },
@@ -9647,11 +9647,11 @@
       }
     },
     "greyscript-interpreter": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.0.tgz",
-      "integrity": "sha512-mqUSkMwWiCxbKPpIswj14VNFctgswO7wDq55dvVcDSTSSUi0DNnZtffOSyUyKzFzH5BrJF3zt05p67dHRYqqdQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.1.tgz",
+      "integrity": "sha512-YgRyN2d4IH5Kz2KiDsRYYGqi5gZoPuCxZAVHF/Z9hRt78qvqy49AwR6jsRWu8SXKLGHxFYZgFq2ak1QUdhbqAg==",
       "requires": {
-        "greybel-interpreter": "~5.6.0",
+        "greybel-interpreter": "~5.6.1",
         "greyscript-core": "~2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.6.47",
+  "version": "3.6.48",
   "engines": {
     "node": ">=20.17.0"
   },
@@ -34,11 +34,11 @@
     "crlf-normalize": "^1.0.20",
     "css-color-names": "^1.0.1",
     "glob": "^11.0.1",
-    "greybel-gh-mock-intrinsics": "~5.6.0",
-    "greybel-intrinsics": "~5.6.0",
+    "greybel-gh-mock-intrinsics": "~5.6.1",
+    "greybel-intrinsics": "~5.6.1",
     "greyhack-message-hook-client": "~0.6.10",
     "greyscript-core": "~2.6.0",
-    "greyscript-interpreter": "~2.6.0",
+    "greyscript-interpreter": "~2.6.1",
     "greyscript-meta": "~4.3.2",
     "greyscript-transpiler": "~1.9.1",
     "lru-cache": "^11.0.2",


### PR DESCRIPTION
Includes:
- allow overidding of globals, locals and outer in interpreter runtime
- remove check on map.push in case of already existing key to emulate in-game behaviour