### PR TITLE
3.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1726,5 +1726,5 @@ All notable changes to this project will be documented in this file.
 
 ## [3.7.5] - 21.09.2025
 
-- update message-hook to add small delay before running pre and post script when running in-game import with auto-compile to prevent temporary script not existing when trying to execute script, causing the whole import to fail due to the inability to add resources - seems like this was randomly happening rather than a consistent issue
+- update message-hook to add small delay before running pre and post script when running in-game import with auto-compile to prevent temporary script not existing when trying to execute script, causing the whole import to fail due to the inability to add resources - seems like this was randomly happening rather than a consistent issue - note that you have to update the message-hook in order to get this fix
 - update meta version which contains some formatting changes for the overflow tooltip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1723,3 +1723,8 @@ All notable changes to this project will be documented in this file.
 
 - fix exit signal not triggering program termination via mock-env runtime
 - update message-hook to use latest game assembly - please update your message-hook - thanks for reporting to IDelta
+
+## [3.7.5] - 21.09.2025
+
+- update message-hook to add small delay before running pre and post script when running in-game import with auto-compile to prevent temporary script not existing when trying to execute script, causing the whole import to fail due to the inability to add resources - seems like this was randomly happening rather than a consistent issue
+- update meta version which contains some formatting changes for the overflow tooltip

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ## BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/bce7661de79ffc1313d7d4e78a0a28b9c725d78c/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/bce99116df66b4e400223b64e8e1edfa4a1a2017/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`
@@ -459,7 +459,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ## BepInEx 6.x.x
 1. **Download BepInEx 6.x.x**: [BepInEx version 6.0.0-pre.2 Unity.Mono](https://github.com/BepInEx/BepInEx/releases/tag/v6.0.0-pre.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/master/articles/user_guide/installation/unity_mono.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/bce7661de79ffc1313d7d4e78a0a28b9c725d78c/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/bce99116df66b4e400223b64e8e1edfa4a1a2017/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-js",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-js",
-      "version": "3.7.4",
+      "version": "3.7.5",
       "dependencies": {
         "@inquirer/core": "^10.1.7",
         "@inquirer/prompts": "^7.3.2",
@@ -26,7 +26,7 @@
         "greyhack-message-hook-client": "~1.2.1",
         "greyscript-core": "~2.6.0",
         "greyscript-interpreter": "~2.6.1",
-        "greyscript-meta": "~4.4.3",
+        "greyscript-meta": "~4.4.4",
         "greyscript-transpiler": "~1.9.1",
         "lru-cache": "^11.0.2",
         "mkdirp": "^3.0.1",
@@ -4078,9 +4078,9 @@
       }
     },
     "node_modules/greyscript-meta": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/greyscript-meta/-/greyscript-meta-4.4.3.tgz",
-      "integrity": "sha512-XnznRCnXo9flHkKxWLhul6mtRbmdW9KfEUPLh7YLFEYWdl4FJmnD61cfdA59HYvHcT9mpi6cFoX0OCSzIJP+UQ==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/greyscript-meta/-/greyscript-meta-4.4.4.tgz",
+      "integrity": "sha512-0rI4mpzqc7SQRKFbPrhAPKnQA8zsPnoWQ1I9Vx18yeH54VU8eyQlHBZped0s+Vah6CGjbXIcELRaKEbdJ/6RpQ==",
       "license": "MIT",
       "dependencies": {
         "meta-utils": "~3.0.0"
@@ -9656,9 +9656,9 @@
       }
     },
     "greyscript-meta": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/greyscript-meta/-/greyscript-meta-4.4.3.tgz",
-      "integrity": "sha512-XnznRCnXo9flHkKxWLhul6mtRbmdW9KfEUPLh7YLFEYWdl4FJmnD61cfdA59HYvHcT9mpi6cFoX0OCSzIJP+UQ==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/greyscript-meta/-/greyscript-meta-4.4.4.tgz",
+      "integrity": "sha512-0rI4mpzqc7SQRKFbPrhAPKnQA8zsPnoWQ1I9Vx18yeH54VU8eyQlHBZped0s+Vah6CGjbXIcELRaKEbdJ/6RpQ==",
       "requires": {
         "meta-utils": "~3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greybel-js",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "engines": {
     "node": ">=20.17.0"
   },
@@ -39,7 +39,7 @@
     "greyhack-message-hook-client": "~1.2.1",
     "greyscript-core": "~2.6.0",
     "greyscript-interpreter": "~2.6.1",
-    "greyscript-meta": "~4.4.3",
+    "greyscript-meta": "~4.4.4",
     "greyscript-transpiler": "~1.9.1",
     "lru-cache": "^11.0.2",
     "greybel-type-analyzer": "~1.1.2",

--- a/src/helper/version-manager.ts
+++ b/src/helper/version-manager.ts
@@ -19,7 +19,7 @@ interface HealthCheckResult {
 }
 
 export class VersionManager {
-  static LATEST_MESSAGE_HOOK_VERSION: string = '1.2.2';
+  static LATEST_MESSAGE_HOOK_VERSION: string = '1.2.3';
   static RESOURCE_LINK: string =
     'https://github.com/ayecue/greybel-js?tab=readme-ov-file#message-hook';
 


### PR DESCRIPTION
Includes:
- update message-hook to add small delay before running pre and post script when running in-game import with auto-compile to prevent temporary script not existing when trying to execute script, causing the whole import to fail due to the inability to add resources - seems like this was randomly happening rather than a consistent issue
- update meta version which contains some formatting changes for the overflow tooltip